### PR TITLE
Add Bitwarden to blacklisted PW manager files

### DIFF
--- a/etc/disable-passwdmgr.inc
+++ b/etc/disable-passwdmgr.inc
@@ -2,6 +2,7 @@
 # Persistent customizations should go in a .local file.
 include /etc/firejail/disable-passwdmgr.local
 
+blacklist ${HOME}/.config/Bitwarden
 blacklist ${HOME}/.config/KeePass
 blacklist ${HOME}/.config/keepass
 blacklist ${HOME}/.config/keepassx


### PR DESCRIPTION
Firejail doesn't currently have Bitwarden's .config directory in its predefined blacklist. This patch adds it.